### PR TITLE
chore(PBE-325): Update Jenkinsfile to push docker image to ghcr

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,25 +1,5 @@
 setup
 
-// dockerRunHook = new DockerRun(
-//     steps: this,
-//     name: "deploy",
-//     stageName: "Deploy {stage}",
-//     image: "global-sf1/semantic-pr-ghcr:1.0.0",
-//     registry: "ghcr.io",
-//     registryCredentials: "github-credentials",
-//     commands: []
-// )
-
 dockerImage([
-    //aws: [role: "jenkins-devops", account: "873328514756"],
-    images: ["global-shared/semantic-pull-requests/semantic-pr-test": ["dockerfile": "docker/Dockerfile"]],
-    registry: "ghcr.io",
-//     imageName: "semantic-pr",
-//     hooks: [dockerRunHook],
-    path: "ghcr.io/global-shared/semantic-pull-requests/semantic-pr-test",
-    pushImage: true,
-    registryCredentials: "github-registry-credentials",
-
-//     registry: "873328514756.dkr.ecr.eu-west-1.amazonaws.com"
-
+    images: ["global-shared/semantic-pull-requests": ["dockerfile": "docker/Dockerfile"]]
 ])


### PR DESCRIPTION
This is part of the migration from ECR to GHCR, looks like SemanticPR was originally used to test out GHCR so I've simplified the Jenkinsfile.

The `images` map is needed as by default `BuildDocker()` looks for the Dockerfile in the root of the directory. 